### PR TITLE
Wrapper for making posts from api + changes to voting

### DIFF
--- a/pydevrant/basic.py
+++ b/pydevrant/basic.py
@@ -88,6 +88,9 @@ class Auth:
         return True
 
     def vote(self, type, rant_id, value):
+        '''
+        Vote on a post or comment
+        '''
         if type == "rant":
             self.voteUrl = "https://devrant.com/api/devrant/rants/"+str(rant_id)+"/vote"
         elif type == "comment":
@@ -106,6 +109,23 @@ class Auth:
             #if user is downvoting, reason needs to be provided
             data["reason"] = 0
         self._res = requests.post(self.voteUrl, data=data)
+        return json.loads(self._res.text)
+
+    def post(self, body, tags, type):
+        '''
+        Make a post from user's account
+        '''
+        self.postUrl = "https://devrant.com/api/devrant/rants"
+        data = {
+            "app": 3,
+            "rant": body,
+            "tags": tags,
+            "token_id": self.token_id,
+            "token_key": self.token_key,
+            "user_id": self.uid,
+            "type": type
+        }
+        self._res = requests.post(self.postUrl, data=data)
         return json.loads(self._res.text)
 
 

--- a/pydevrant/basic.py
+++ b/pydevrant/basic.py
@@ -87,8 +87,11 @@ class Auth:
         self.token_key = json.loads(self._res.text)['auth_token']['key']
         return True
 
-    def vote(self, rant_id, value):
-        endpoint = "https://devrant.com/api/devrant/rants/"+str(rant_id)+"/vote"
+    def vote(self, type, rant_id, value):
+        if type == "rant":
+            self.voteUrl = "https://devrant.com/api/devrant/rants/"+str(rant_id)+"/vote"
+        elif type == "comment":
+            self.voteUrl = "https://devrant.com/api/comments/"+str(rant_id)+"/vote"
         data = {
             "app": 3,
             "token_id": self.token_id,
@@ -102,7 +105,7 @@ class Auth:
         if value == -1:
             #if user is downvoting, reason needs to be provided
             data["reason"] = 0
-        self._res = requests.post(endpoint, data=data)
+        self._res = requests.post(self.voteUrl, data=data)
         return json.loads(self._res.text)
 
 


### PR DESCRIPTION
Users can now make posts directly from api. (rants AND collabs)

**usage:**
```python
client = Auth()
user = client.login("USERNAME", "PASSWORD")

#first argument is body (string)
#second argument is tags (string, make sure comma seperated)
#third argument is type (int, 1 for rant, 5 for collab)
client.post("this is my rant, do you like it?", "swift, react, js", 1)
```

Users can now vote on both comments AND rants. you have to specify a type now, which must be a string

**voting example:**
```python
client.vote("rant", 1292812, +1)    #for voting on a rant
client.vote("comment", 1372121, +1)    #for voting on a comment
```
